### PR TITLE
Fixed sidebar using media queries

### DIFF
--- a/snippet_share_project/snip_app/templates/base.html
+++ b/snippet_share_project/snip_app/templates/base.html
@@ -84,7 +84,14 @@
           </div>
         </div>
 
-        <div class="column is-one-quarter sidebar" style="margin-left: 40px ;">
+        <div class="column is-one-quarter sidebar">
+          <style> .sidebar{margin-left:40px; margin-right:1rem;}
+              @media (max-width: 400px) {
+                  .sidebar {
+                      margin-left:1rem;
+                  }
+}
+</style>
           <article class="panel is-info">
             <p class="panel-heading">
               All Snippets:


### PR DESCRIPTION
@PragatiVerma18 Sidebar had margin-left:40px earlier. But in mobile view it was extra unneeded space. So, I've replaced it with 1rem space both ends on left and right in mobile view.

Thanks for the opportunity :)

<img width="321" alt="Screenshot 2021-01-23 at 14 34 43" src="https://user-images.githubusercontent.com/50984984/105574322-d0357880-5d89-11eb-81e7-d43b92d81119.png">
